### PR TITLE
feat: add custom theme upload and crop flow

### DIFF
--- a/src/features/configurator/configurator-content.tsx
+++ b/src/features/configurator/configurator-content.tsx
@@ -12,13 +12,19 @@ import {
   headingAlignmentOptions,
 } from "@/lib/theme";
 import { useContentThemeStore } from "@/store/theme";
+import { CustomThemeCropper } from "./custom-theme-cropper";
 import { ThemeGrid } from "./theme-grid";
 
 export const ConfiguratorContent = () => {
   const {
     currentThemeId,
+    customThemes,
+    themeError,
+    selectTheme,
+    startCustomThemeUpload,
+    deleteCustomTheme,
+    clearThemeError,
     adjustments,
-    selectPresetTheme,
     setDensity,
     setFont,
     setHeadingAlignment,
@@ -36,7 +42,12 @@ export const ConfiguratorContent = () => {
         <Label className="font-medium text-xs">主题</Label>
         <ThemeGrid
           currentThemeId={currentThemeId}
-          onSelect={selectPresetTheme}
+          customThemes={customThemes}
+          onClearError={clearThemeError}
+          onDeleteCustomTheme={deleteCustomTheme}
+          onSelect={selectTheme}
+          onStartUpload={startCustomThemeUpload}
+          themeError={themeError}
         />
       </div>
 
@@ -82,6 +93,8 @@ export const ConfiguratorContent = () => {
           重置风格
         </button>
       )}
+
+      <CustomThemeCropper />
     </div>
   );
 };

--- a/src/features/configurator/custom-theme-cropper.tsx
+++ b/src/features/configurator/custom-theme-cropper.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Label } from "@/components/ui/label";
+import { useDevice } from "@/features/layouts/hooks/use-device";
+import {
+  CUSTOM_THEME_SCALE_MAX,
+  CUSTOM_THEME_SCALE_MIN,
+  getPreviewImageLayout,
+} from "@/lib/theme/custom-theme-image";
+import { cn } from "@/lib/utils";
+import { useContentThemeStore } from "@/store/theme";
+
+export const CustomThemeCropper = () => {
+  const {
+    pendingUpload,
+    isCropperOpen,
+    updatePendingCrop,
+    cancelCustomThemeUpload,
+    commitCustomThemeCrop,
+  } = useContentThemeStore();
+  const { isMobile } = useDevice();
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const dragStartRef = useRef<{
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    cropX: number;
+    cropY: number;
+  } | null>(null);
+  const [frameElement, setFrameElement] = useState<HTMLDivElement | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [frameSize, setFrameSize] = useState({ width: 0, height: 0 });
+
+  useLayoutEffect(() => {
+    if (!frameElement) {
+      return;
+    }
+
+    const updateFrameSize = () => {
+      const nextWidth = frameElement.clientWidth;
+      const nextHeight = frameElement.clientHeight;
+
+      setFrameSize((currentSize) => {
+        if (
+          currentSize.width === nextWidth &&
+          currentSize.height === nextHeight
+        ) {
+          return currentSize;
+        }
+
+        return {
+          width: nextWidth,
+          height: nextHeight,
+        };
+      });
+    };
+
+    updateFrameSize();
+
+    const observer = new ResizeObserver(([entry]) => {
+      const nextWidth = entry.contentRect.width;
+      const nextHeight = entry.contentRect.height;
+
+      setFrameSize((currentSize) => {
+        if (
+          currentSize.width === nextWidth &&
+          currentSize.height === nextHeight
+        ) {
+          return currentSize;
+        }
+
+        return {
+          width: nextWidth,
+          height: nextHeight,
+        };
+      });
+    });
+
+    observer.observe(frameElement);
+
+    window.addEventListener("resize", updateFrameSize);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateFrameSize);
+    };
+  }, [frameElement]);
+
+  useEffect(() => {
+    if (!isCropperOpen || isMobile) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isSaving) {
+        cancelCustomThemeUpload();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [cancelCustomThemeUpload, isCropperOpen, isMobile, isSaving]);
+
+  const previewLayout = useMemo(() => {
+    if (!pendingUpload || frameSize.width <= 0 || frameSize.height <= 0) {
+      return null;
+    }
+
+    return getPreviewImageLayout(
+      pendingUpload.crop,
+      frameSize.width,
+      frameSize.height
+    );
+  }, [frameSize.height, frameSize.width, pendingUpload]);
+
+  if (!pendingUpload) {
+    return null;
+  }
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!previewLayout) {
+      return;
+    }
+
+    dragStartRef.current = {
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      cropX: pendingUpload.crop.x,
+      cropY: pendingUpload.crop.y,
+    };
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!(dragStartRef.current && previewLayout)) {
+      return;
+    }
+
+    if (dragStartRef.current.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - dragStartRef.current.clientX;
+    const deltaY = event.clientY - dragStartRef.current.clientY;
+
+    updatePendingCrop({
+      x: dragStartRef.current.cropX - deltaX / previewLayout.previewScale,
+      y: dragStartRef.current.cropY - deltaY / previewLayout.previewScale,
+    });
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStartRef.current?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    dragStartRef.current = null;
+    setIsDragging(false);
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    await commitCustomThemeCrop(
+      pendingUpload.basePresetThemeId,
+      pendingUpload.themeName
+    );
+    setIsSaving(false);
+  };
+
+  const cropperContent = (
+    <div className="space-y-5">
+      <div className="space-y-1">
+        <h3 className="font-medium text-base">裁剪背景图</h3>
+        <p className="text-muted-foreground text-sm">
+          拖动调整位置，固定 3:4 比例裁剪后保存为主题背景。
+        </p>
+      </div>
+
+      <div className="mx-auto w-full max-w-[320px]">
+        <div
+          className={cn(
+            "relative aspect-[3/4] overflow-hidden rounded-[28px] bg-muted/60 ring-1 ring-border",
+            isDragging ? "cursor-grabbing" : "cursor-grab"
+          )}
+          onPointerCancel={handlePointerUp}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          ref={(node) => {
+            frameRef.current = node;
+            setFrameElement(node);
+          }}
+          style={{ touchAction: "none" }}
+        >
+          {previewLayout ? (
+            <div
+              aria-label={pendingUpload.themeName}
+              className="pointer-events-none absolute select-none"
+              role="img"
+              style={{
+                backgroundImage: `url(${pendingUpload.imageDataUrl})`,
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat",
+                backgroundSize: "100% 100%",
+                height: `${previewLayout.height}px`,
+                left: `${previewLayout.left}px`,
+                top: `${previewLayout.top}px`,
+                width: `${previewLayout.width}px`,
+              }}
+            />
+          ) : null}
+          <div className="pointer-events-none absolute inset-0 rounded-[28px] ring-2 ring-white/80 ring-offset-0" />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-linear-to-t from-black/45 to-transparent px-4 py-4 text-white">
+            <div className="font-medium text-sm">{pendingUpload.themeName}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="font-medium text-xs">缩放</Label>
+          <span className="text-muted-foreground text-xs">
+            {pendingUpload.crop.scale.toFixed(2)}x
+          </span>
+        </div>
+        <input
+          className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+          max={CUSTOM_THEME_SCALE_MAX}
+          min={CUSTOM_THEME_SCALE_MIN}
+          onChange={(event) =>
+            updatePendingCrop({ scale: Number(event.target.value) })
+          }
+          step={0.01}
+          type="range"
+          value={pendingUpload.crop.scale}
+        />
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer
+        onOpenChange={(open) => {
+          if (!(open || isSaving)) {
+            cancelCustomThemeUpload();
+          }
+        }}
+        open={isCropperOpen}
+      >
+        <DrawerContent className="min-h-[92vh]">
+          <DrawerHeader>
+            <DrawerTitle>裁剪主题背景</DrawerTitle>
+            <DrawerDescription>
+              上传图片会按 3:4 输出，导出效果和预览保持一致。
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="overflow-auto px-4 pb-4">{cropperContent}</div>
+          <DrawerFooter>
+            <Button
+              disabled={isSaving}
+              onClick={cancelCustomThemeUpload}
+              size="lg"
+              variant="outline"
+            >
+              取消
+            </Button>
+            <Button disabled={isSaving} onClick={handleSave} size="lg">
+              {isSaving ? "保存中..." : "保存主题"}
+            </Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  return isCropperOpen ? (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-[32px] border border-border bg-background p-6 shadow-2xl">
+        {cropperContent}
+        <div className="mt-6 flex items-center justify-end gap-2">
+          <Button
+            disabled={isSaving}
+            onClick={cancelCustomThemeUpload}
+            variant="outline"
+          >
+            取消
+          </Button>
+          <Button disabled={isSaving} onClick={handleSave}>
+            {isSaving ? "保存中..." : "保存主题"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+};

--- a/src/features/configurator/floating-configurator.tsx
+++ b/src/features/configurator/floating-configurator.tsx
@@ -29,7 +29,7 @@ export const FloatingConfigurator = () => {
   }
 
   return (
-    <div className="fade-in slide-in-from-bottom-2 fixed top-14 right-6 z-30 w-[240px] animate-in duration-200">
+    <div className="fade-in slide-in-from-bottom-2 fixed top-14 right-6 z-30 w-[280px] animate-in duration-200">
       <div className="max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-background/95 p-4 shadow-lg backdrop-blur-md">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium text-sm">样式设置</span>

--- a/src/features/configurator/theme-grid.tsx
+++ b/src/features/configurator/theme-grid.tsx
@@ -1,12 +1,24 @@
 "use client";
 
-import { presetThemes } from "@/lib/theme";
-import type { PresetTheme } from "@/lib/theme/types";
+import { Delete02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useRef, useState } from "react";
+import { Tooltip } from "@/components/tooltip";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CUSTOM_THEME_MAX_COUNT } from "@/lib/theme/custom-theme-image";
+import { getResolvedThemeById, presetThemes } from "@/lib/theme/themes";
+import type { CustomThemeRecord, PresetTheme } from "@/lib/theme/types";
 import { cn } from "@/lib/utils";
 
 interface ThemeGridProps {
   currentThemeId: string;
+  customThemes: CustomThemeRecord[];
+  onClearError: () => void;
+  onDeleteCustomTheme: (themeId: string) => void;
   onSelect: (themeId: string) => void;
+  onStartUpload: (file: File) => Promise<void>;
+  themeError: string | null;
 }
 
 function getThemeBackground(theme: PresetTheme): React.CSSProperties {
@@ -20,31 +32,169 @@ function getThemeBackground(theme: PresetTheme): React.CSSProperties {
   return { backgroundColor: bg.value };
 }
 
-export const ThemeGrid = ({ currentThemeId, onSelect }: ThemeGridProps) => (
-  <div className="grid grid-cols-2 gap-2">
-    {presetThemes.map((theme) => (
-      <button
-        className={cn(
-          "group relative flex h-20 flex-col items-center justify-end overflow-hidden rounded-lg border-2 p-2 transition-all",
-          theme.id === currentThemeId
-            ? "border-primary shadow-sm"
-            : "border-transparent hover:border-muted-foreground/30"
-        )}
-        key={theme.id}
-        onClick={() => onSelect(theme.id)}
-        style={getThemeBackground(theme)}
-        type="button"
-      >
-        <span
-          className="rounded-sm px-1.5 py-0.5 font-medium text-[10px] leading-tight backdrop-blur-sm"
-          style={{
-            color: theme.style.heading.color,
-            backgroundColor: "rgba(255,255,255,0.3)",
-          }}
-        >
-          {theme.name}
-        </span>
-      </button>
-    ))}
-  </div>
-);
+export const ThemeGrid = ({
+  currentThemeId,
+  customThemes,
+  themeError,
+  onClearError,
+  onDeleteCustomTheme,
+  onSelect,
+  onStartUpload,
+}: ThemeGridProps) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFileChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      await onStartUpload(file);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <input
+        accept="image/png,image/jpeg,image/webp"
+        className="sr-only"
+        onChange={handleFileChange}
+        ref={fileInputRef}
+        type="file"
+      />
+
+      {themeError ? (
+        <div className="rounded-2xl border border-destructive/20 bg-destructive/5 p-3 text-destructive text-sm">
+          <div className="flex items-start justify-between gap-3">
+            <p className="leading-5">{themeError}</p>
+            <button
+              className="text-xs opacity-70 transition-opacity hover:opacity-100"
+              onClick={onClearError}
+              type="button"
+            >
+              关闭
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-xs">我的主题</span>
+          <Badge variant="outline">
+            {customThemes.length}/{CUSTOM_THEME_MAX_COUNT}
+          </Badge>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            className="flex h-20 flex-col items-center justify-center rounded-2xl border border-border border-dashed bg-muted/35 px-2 text-center transition-colors hover:bg-muted/60"
+            onClick={() => fileInputRef.current?.click()}
+            type="button"
+          >
+            <span className="font-medium text-xs">
+              {isUploading ? "处理中..." : "上传图片"}
+            </span>
+            <span className="mt-1 text-[10px] text-muted-foreground">
+              生成自定义背景主题
+            </span>
+          </button>
+
+          {customThemes.map((customTheme) => {
+            const resolvedTheme = getResolvedThemeById(
+              customTheme.id,
+              customThemes
+            );
+            if (!resolvedTheme) {
+              return null;
+            }
+
+            return (
+              <div className="relative" key={customTheme.id}>
+                <button
+                  className={cn(
+                    "group relative flex h-20 w-full flex-col items-start justify-end overflow-hidden rounded-2xl border-2 p-2 text-left transition-all",
+                    customTheme.id === currentThemeId
+                      ? "border-primary shadow-sm"
+                      : "border-transparent hover:border-muted-foreground/30"
+                  )}
+                  onClick={() => onSelect(customTheme.id)}
+                  style={getThemeBackground(resolvedTheme)}
+                  type="button"
+                >
+                  <span className="w-full rounded-lg bg-black/30 px-2 py-1 font-medium text-[10px] text-white leading-tight backdrop-blur-sm">
+                    {customTheme.name}
+                  </span>
+                </button>
+                <Tooltip content="删除主题">
+                  <Button
+                    aria-label={`删除主题 ${customTheme.name}`}
+                    className="absolute top-1.5 right-1.5 h-6 w-6 rounded-full bg-background/85 p-0 text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDeleteCustomTheme(customTheme.id);
+                    }}
+                    size="xs"
+                    type="button"
+                    variant="outline"
+                  >
+                    <HugeiconsIcon
+                      className="h-3.5 w-3.5"
+                      icon={Delete02Icon}
+                      strokeWidth={1.8}
+                    />
+                  </Button>
+                </Tooltip>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-xs">系统主题</span>
+          <span className="text-[10px] text-muted-foreground">
+            上传图片后会继承当前主题文字样式
+          </span>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          {presetThemes.map((theme) => (
+            <button
+              className={cn(
+                "group relative flex h-20 flex-col items-center justify-end overflow-hidden rounded-2xl border-2 p-2 transition-all",
+                theme.id === currentThemeId
+                  ? "border-primary shadow-sm"
+                  : "border-transparent hover:border-muted-foreground/30"
+              )}
+              key={theme.id}
+              onClick={() => onSelect(theme.id)}
+              style={getThemeBackground(theme)}
+              type="button"
+            >
+              <span
+                className="rounded-lg px-2 py-1 font-medium text-[10px] leading-tight backdrop-blur-sm"
+                style={{
+                  color: theme.style.heading.color,
+                  backgroundColor: "rgba(255,255,255,0.32)",
+                }}
+              >
+                {theme.name}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/layouts/index.tsx
+++ b/src/features/layouts/index.tsx
@@ -1,11 +1,18 @@
 "use client";
 
+import { useEffect } from "react";
+import { useContentThemeStore } from "@/store/theme";
 import { DesktopLayout } from "./desktop-layout";
 import { useDevice } from "./hooks/use-device";
 import { MobileLayout } from "./mobile-layout";
 
 export function Layout(): React.ReactElement | null {
   const { isMobile, isHydrated } = useDevice();
+  const { hydrateCustomThemes } = useContentThemeStore();
+
+  useEffect(() => {
+    hydrateCustomThemes().catch(() => undefined);
+  }, [hydrateCustomThemes]);
 
   if (!isHydrated) {
     return null;

--- a/src/features/preview/image-preview.tsx
+++ b/src/features/preview/image-preview.tsx
@@ -3,25 +3,22 @@
 import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import type { ImageSegment } from "@/lib/markdown-parser";
-import {
-  applyAdjustments,
-  defaultTheme,
-  generateStyles,
-  getThemeById,
-} from "@/lib/theme";
+import { applyAdjustments, defaultTheme, generateStyles } from "@/lib/theme";
+import { getResolvedThemeById } from "@/lib/theme/themes";
 import { useContentThemeStore } from "@/store/theme";
 import { HeaderBar } from "./header-bar";
 
 interface ImagePreviewProps {
-  segment: ImageSegment;
   ref?: React.Ref<HTMLDivElement>;
+  segment: ImageSegment;
 }
 
 export const ImagePreview: React.FC<ImagePreviewProps> = ({ segment, ref }) => {
-  const { currentThemeId, adjustments } = useContentThemeStore();
+  const { currentThemeId, customThemes, adjustments } = useContentThemeStore();
 
   const { styles, headerBar } = useMemo(() => {
-    const theme = getThemeById(currentThemeId) ?? defaultTheme;
+    const theme =
+      getResolvedThemeById(currentThemeId, customThemes) ?? defaultTheme;
     const adjustedStyle = applyAdjustments(theme.style, adjustments);
     // 如果是封面图（包含 # 一级标题），使用主题的封面图样式，忽略用户的标题对齐设置
     const coverStyle = segment.isCover ? theme.coverStyle : undefined;
@@ -29,7 +26,7 @@ export const ImagePreview: React.FC<ImagePreviewProps> = ({ segment, ref }) => {
       styles: generateStyles(adjustedStyle, { coverStyle }),
       headerBar: theme.headerBar,
     };
-  }, [currentThemeId, adjustments, segment.isCover]);
+  }, [adjustments, currentThemeId, customThemes, segment.isCover]);
 
   return (
     <div className="img-preview" ref={ref} style={styles.container}>

--- a/src/features/preview/segment-filmstrip.tsx
+++ b/src/features/preview/segment-filmstrip.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import type { ImageSegment } from "@/lib/markdown-parser";
-import { defaultTheme, getThemeById } from "@/lib/theme";
+import { defaultTheme } from "@/lib/theme";
+import { getResolvedThemeById } from "@/lib/theme/themes";
 import { cn } from "@/lib/utils";
 import { useContentThemeStore } from "@/store/theme";
 
@@ -31,15 +32,16 @@ export const SegmentFilmstrip = ({
   onSelect,
 }: SegmentFilmstripProps) => {
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const { currentThemeId } = useContentThemeStore();
+  const { currentThemeId, customThemes } = useContentThemeStore();
 
   const thumbnailStyle = useMemo(() => {
-    const theme = getThemeById(currentThemeId) ?? defaultTheme;
+    const theme =
+      getResolvedThemeById(currentThemeId, customThemes) ?? defaultTheme;
     return {
       ...getBackgroundCss(theme.style.background),
       color: theme.style.heading.color,
     };
-  }, [currentThemeId]);
+  }, [currentThemeId, customThemes]);
 
   useEffect(() => {
     const activeItem = itemRefs.current[activeIndex];

--- a/src/lib/theme/custom-theme-image.ts
+++ b/src/lib/theme/custom-theme-image.ts
@@ -1,0 +1,180 @@
+import type { CustomThemeCrop } from "./types";
+
+const FILE_EXTENSION_PATTERN = /\.[^.]+$/;
+
+export const CUSTOM_THEME_MAX_COUNT = 20;
+export const CUSTOM_THEME_MAX_FILE_SIZE = 10 * 1024 * 1024;
+export const CUSTOM_THEME_OUTPUT_WIDTH = 1125;
+export const CUSTOM_THEME_OUTPUT_HEIGHT = 1500;
+export const CUSTOM_THEME_OUTPUT_QUALITY = 0.82;
+export const CUSTOM_THEME_ASPECT_RATIO =
+  CUSTOM_THEME_OUTPUT_WIDTH / CUSTOM_THEME_OUTPUT_HEIGHT;
+export const CUSTOM_THEME_SCALE_MIN = 1;
+export const CUSTOM_THEME_SCALE_MAX = 4;
+export const CUSTOM_THEME_ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+
+export function getThemeNameFromFile(fileName: string): string {
+  const normalized = fileName.replace(FILE_EXTENSION_PATTERN, "").trim();
+  return normalized || "我的主题";
+}
+
+export function validateCustomThemeFile(file: File): void {
+  if (!CUSTOM_THEME_ACCEPTED_TYPES.includes(file.type)) {
+    throw new Error("仅支持 PNG、JPG、WebP 图片");
+  }
+
+  if (file.size > CUSTOM_THEME_MAX_FILE_SIZE) {
+    throw new Error("图片不能超过 10MB");
+  }
+}
+
+export function clampCustomThemeScale(scale: number): number {
+  return Math.min(
+    CUSTOM_THEME_SCALE_MAX,
+    Math.max(CUSTOM_THEME_SCALE_MIN, scale)
+  );
+}
+
+function getBaseCropSize(sourceWidth: number, sourceHeight: number) {
+  const sourceRatio = sourceWidth / sourceHeight;
+
+  if (sourceRatio >= CUSTOM_THEME_ASPECT_RATIO) {
+    return {
+      width: sourceHeight * CUSTOM_THEME_ASPECT_RATIO,
+      height: sourceHeight,
+    };
+  }
+
+  return {
+    width: sourceWidth,
+    height: sourceWidth / CUSTOM_THEME_ASPECT_RATIO,
+  };
+}
+
+export function getDefaultCustomThemeCrop(
+  sourceWidth: number,
+  sourceHeight: number
+): CustomThemeCrop {
+  return {
+    x: sourceWidth / 2,
+    y: sourceHeight / 2,
+    scale: CUSTOM_THEME_SCALE_MIN,
+    sourceWidth,
+    sourceHeight,
+  };
+}
+
+export function clampCustomThemeCrop(crop: CustomThemeCrop): CustomThemeCrop {
+  const scale = clampCustomThemeScale(crop.scale);
+  const baseCropSize = getBaseCropSize(crop.sourceWidth, crop.sourceHeight);
+  const cropWidth = baseCropSize.width / scale;
+  const cropHeight = baseCropSize.height / scale;
+
+  return {
+    ...crop,
+    scale,
+    x: Math.min(
+      crop.sourceWidth - cropWidth / 2,
+      Math.max(cropWidth / 2, crop.x)
+    ),
+    y: Math.min(
+      crop.sourceHeight - cropHeight / 2,
+      Math.max(cropHeight / 2, crop.y)
+    ),
+  };
+}
+
+export function getCustomThemeCropRect(crop: CustomThemeCrop) {
+  const clampedCrop = clampCustomThemeCrop(crop);
+  const baseCropSize = getBaseCropSize(
+    clampedCrop.sourceWidth,
+    clampedCrop.sourceHeight
+  );
+  const width = baseCropSize.width / clampedCrop.scale;
+  const height = baseCropSize.height / clampedCrop.scale;
+
+  return {
+    left: clampedCrop.x - width / 2,
+    top: clampedCrop.y - height / 2,
+    width,
+    height,
+  };
+}
+
+export function getPreviewImageLayout(
+  crop: CustomThemeCrop,
+  frameWidth: number,
+  frameHeight: number
+) {
+  const cropRect = getCustomThemeCropRect(crop);
+  const previewScale = frameWidth / cropRect.width;
+  const imageWidth = crop.sourceWidth * previewScale;
+  const imageHeight = crop.sourceHeight * previewScale;
+
+  return {
+    width: imageWidth,
+    height: imageHeight,
+    left: frameWidth / 2 - crop.x * previewScale,
+    top: frameHeight / 2 - crop.y * previewScale,
+    previewScale,
+  };
+}
+
+export function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+        return;
+      }
+      reject(new Error("图片读取失败，请重试"));
+    };
+    reader.onerror = () => reject(new Error("图片读取失败，请重试"));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function loadImage(source: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("图片加载失败，请更换文件"));
+    image.src = source;
+  });
+}
+
+export async function renderCroppedThemeImage(
+  imageSource: string,
+  crop: CustomThemeCrop
+): Promise<string> {
+  const image = await loadImage(imageSource);
+  const cropRect = getCustomThemeCropRect(crop);
+  const canvas = document.createElement("canvas");
+  canvas.width = CUSTOM_THEME_OUTPUT_WIDTH;
+  canvas.height = CUSTOM_THEME_OUTPUT_HEIGHT;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("当前环境不支持图片裁剪，请稍后重试");
+  }
+
+  context.drawImage(
+    image,
+    cropRect.left,
+    cropRect.top,
+    cropRect.width,
+    cropRect.height,
+    0,
+    0,
+    CUSTOM_THEME_OUTPUT_WIDTH,
+    CUSTOM_THEME_OUTPUT_HEIGHT
+  );
+
+  return canvas.toDataURL("image/webp", CUSTOM_THEME_OUTPUT_QUALITY);
+}

--- a/src/lib/theme/custom-theme-indexed-db.ts
+++ b/src/lib/theme/custom-theme-indexed-db.ts
@@ -1,0 +1,121 @@
+import type { CustomThemeRecord } from "./types";
+
+const DATABASE_NAME = "redbook-text2img-custom-themes";
+const DATABASE_VERSION = 1;
+const STORE_NAME = "theme-images";
+
+function supportsIndexedDb(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  if (!supportsIndexedDb()) {
+    return Promise.reject(new Error("当前浏览器不支持本地主题存储"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+
+    request.onerror = () =>
+      reject(request.error ?? new Error("自定义主题数据库打开失败"));
+
+    request.onupgradeneeded = () => {
+      const database = request.result;
+
+      if (!database.objectStoreNames.contains(STORE_NAME)) {
+        database.createObjectStore(STORE_NAME);
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  executor: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+  const database = await openDatabase();
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    const request = executor(store);
+
+    request.onerror = () =>
+      reject(request.error ?? new Error("自定义主题存储操作失败"));
+    request.onsuccess = () => resolve(request.result);
+
+    transaction.oncomplete = () => database.close();
+    transaction.onerror = () => {
+      reject(transaction.error ?? new Error("自定义主题存储事务失败"));
+      database.close();
+    };
+    transaction.onabort = () => {
+      reject(transaction.error ?? new Error("自定义主题存储事务已中止"));
+      database.close();
+    };
+  });
+}
+
+export function getCustomThemeImage(
+  imageStorageKey: string
+): Promise<string | undefined> {
+  if (!supportsIndexedDb()) {
+    return Promise.resolve(undefined);
+  }
+
+  return withStore("readonly", (store) => store.get(imageStorageKey));
+}
+
+export function saveCustomThemeImage(
+  imageStorageKey: string,
+  imageDataUrl: string
+): Promise<void> {
+  return withStore("readwrite", (store) =>
+    store.put(imageDataUrl, imageStorageKey)
+  ).then(() => undefined);
+}
+
+export function deleteCustomThemeImage(imageStorageKey: string): Promise<void> {
+  if (!supportsIndexedDb()) {
+    return Promise.resolve();
+  }
+
+  return withStore("readwrite", (store) => store.delete(imageStorageKey)).then(
+    () => undefined
+  );
+}
+
+export async function hydrateCustomThemeRecords(
+  customThemes: CustomThemeRecord[]
+): Promise<CustomThemeRecord[]> {
+  const hydratedThemes: CustomThemeRecord[] = [];
+
+  for (const theme of customThemes) {
+    const imageStorageKey = theme.imageStorageKey ?? theme.id;
+    let backgroundImageDataUrl = theme.backgroundImageDataUrl;
+
+    if (backgroundImageDataUrl) {
+      try {
+        await saveCustomThemeImage(imageStorageKey, backgroundImageDataUrl);
+      } catch {
+        // Keep the in-memory image data if IndexedDB migration fails.
+      }
+    } else {
+      backgroundImageDataUrl = await getCustomThemeImage(imageStorageKey);
+    }
+
+    if (!backgroundImageDataUrl) {
+      continue;
+    }
+
+    hydratedThemes.push({
+      ...theme,
+      backgroundImageDataUrl,
+      imageStorageKey,
+    });
+  }
+
+  return hydratedThemes;
+}

--- a/src/lib/theme/themes.ts
+++ b/src/lib/theme/themes.ts
@@ -5,7 +5,13 @@
 
 import { TrianglifyGary } from "./backgroundSet";
 import { colors, gradients, spacing, typography } from "./tokens";
-import type { CoverStyleOverride, FullStyle, PresetTheme } from "./types";
+import type {
+  CoverStyleOverride,
+  CustomThemeRecord,
+  FullStyle,
+  PresetTheme,
+  ResolvedTheme,
+} from "./types";
 
 // ============================================================
 // 基础样式模板（内部使用）
@@ -331,3 +337,72 @@ export const defaultTheme = presetThemes[0];
 /** Get theme style by ID, with fallback to default */
 export const getThemeStyle = (id: string): FullStyle =>
   getThemeById(id)?.style ?? defaultTheme.style;
+
+export const getBasePresetThemeId = (
+  themeId: string,
+  customThemes: CustomThemeRecord[]
+): string => {
+  const presetTheme = getThemeById(themeId);
+  if (presetTheme) {
+    return presetTheme.id;
+  }
+
+  return (
+    customThemes.find((theme) => theme.id === themeId)?.basePresetThemeId ??
+    defaultTheme.id
+  );
+};
+
+export const getResolvedThemeById = (
+  id: string,
+  customThemes: CustomThemeRecord[]
+): ResolvedTheme | undefined => {
+  const presetTheme = getThemeById(id);
+
+  if (presetTheme) {
+    return {
+      ...presetTheme,
+      source: "preset",
+      basePresetThemeId: presetTheme.id,
+    };
+  }
+
+  const customTheme = customThemes.find((theme) => theme.id === id);
+  if (!customTheme) {
+    return;
+  }
+
+  const baseTheme = getThemeById(customTheme.basePresetThemeId) ?? defaultTheme;
+
+  return {
+    ...baseTheme,
+    id: customTheme.id,
+    name: customTheme.name,
+    style: {
+      ...baseTheme.style,
+      background: customTheme.backgroundImageDataUrl
+        ? {
+            type: "image",
+            value: customTheme.backgroundImageDataUrl,
+          }
+        : baseTheme.style.background,
+    },
+    source: "custom",
+    basePresetThemeId: baseTheme.id,
+  };
+};
+
+export const getAllResolvedThemes = (
+  customThemes: CustomThemeRecord[]
+): ResolvedTheme[] => [
+  ...customThemes
+    .slice()
+    .sort((left, right) => right.createdAt - left.createdAt)
+    .map((theme) => getResolvedThemeById(theme.id, customThemes))
+    .filter((theme): theme is ResolvedTheme => Boolean(theme)),
+  ...presetThemes.map((theme) => ({
+    ...theme,
+    source: "preset" as const,
+    basePresetThemeId: theme.id,
+  })),
+];

--- a/src/lib/theme/types.ts
+++ b/src/lib/theme/types.ts
@@ -38,11 +38,11 @@ export interface EmphasisStyle {
     color: string;
     fontWeight: number;
   };
-  italic: {
-    color: string;
-  };
   highlight: {
     background: string;
+    color: string;
+  };
+  italic: {
     color: string;
   };
 }
@@ -55,16 +55,16 @@ export interface ListStyle {
 export interface BlockquoteStyle {
   background: string;
   borderColor: string;
-  textColor: string;
   boxShadow?: string;
+  textColor: string;
 }
 
 export interface CodeStyle {
-  inline: {
+  block: {
     background: string;
     color: string;
   };
-  block: {
+  inline: {
     background: string;
     color: string;
   };
@@ -76,23 +76,23 @@ export interface LinkStyle {
 }
 
 export interface SpacingStyle {
+  headingGap: number;
   padding: number;
   paragraphGap: number;
-  headingGap: number;
 }
 
 /** Layer 2: Complete style configuration for Markdown rendering */
 export interface FullStyle {
   background: BackgroundStyle;
-  typography: TypographyStyle;
-  heading: HeadingStyle;
-  paragraph: ParagraphStyle;
-  emphasis: EmphasisStyle;
-  list: ListStyle;
   blockquote: BlockquoteStyle;
   code: CodeStyle;
+  emphasis: EmphasisStyle;
+  heading: HeadingStyle;
   link: LinkStyle;
+  list: ListStyle;
+  paragraph: ParagraphStyle;
   spacing: SpacingStyle;
+  typography: TypographyStyle;
 }
 
 // ============================================================
@@ -118,20 +118,20 @@ export interface StyleAdjustments {
 
 /** 封面图特有的样式覆盖 */
 export interface CoverStyleOverride {
-  /** 内容垂直对齐方式 */
-  contentVerticalAlign?: "top" | "center" | "bottom";
   /** 内容水平对齐方式 */
   contentHorizontalAlign?: "left" | "center" | "right";
+  /** 内容垂直对齐方式 */
+  contentVerticalAlign?: "top" | "center" | "bottom";
   /** 标题对齐方式（优先级高于用户调整） */
   headingAlignment?: HeadingAlignment;
 }
 
 /** 装饰性顶部导航栏（如 Apple Notes 风格） */
 export interface HeaderBarStyle {
-  /** 图标颜色 */
-  iconColor: string;
   /** 背景颜色（可以是透明） */
   background?: string;
+  /** 图标颜色 */
+  iconColor: string;
   /** 显示哪些图标 */
   icons: {
     backArrow?: boolean;
@@ -142,12 +142,42 @@ export interface HeaderBarStyle {
 
 /** Layer 1: Preset theme with complete FullStyle */
 export interface PresetTheme {
-  id: string;
-  name: string;
-  description?: string;
-  style: FullStyle; // 直接包含完整样式，不再是 config
   /** 封面图特有的样式覆盖（继承 style，仅覆盖指定属性） */
   coverStyle?: CoverStyleOverride;
+  description?: string;
   /** 装饰性顶部导航栏 */
   headerBar?: HeaderBarStyle;
+  id: string;
+  name: string;
+  style: FullStyle; // 直接包含完整样式，不再是 config
+}
+
+export interface CustomThemeCrop {
+  scale: number;
+  sourceHeight: number;
+  sourceWidth: number;
+  x: number;
+  y: number;
+}
+
+export interface CustomThemeRecord {
+  backgroundImageDataUrl?: string;
+  basePresetThemeId: string;
+  createdAt: number;
+  crop: CustomThemeCrop;
+  id: string;
+  imageStorageKey: string;
+  name: string;
+}
+
+export interface PendingCustomThemeUpload {
+  basePresetThemeId: string;
+  crop: CustomThemeCrop;
+  imageDataUrl: string;
+  themeName: string;
+}
+
+export interface ResolvedTheme extends PresetTheme {
+  basePresetThemeId: string;
+  source: "preset" | "custom";
 }

--- a/src/store/theme.ts
+++ b/src/store/theme.ts
@@ -4,44 +4,332 @@ import {
   type Density,
   defaultAdjustments,
   defaultTheme,
-  getThemeById,
   type HeadingAlignment,
   type StyleAdjustments,
 } from "@/lib/theme";
+import {
+  CUSTOM_THEME_MAX_COUNT,
+  clampCustomThemeCrop,
+  getDefaultCustomThemeCrop,
+  getThemeNameFromFile,
+  readFileAsDataUrl,
+  renderCroppedThemeImage,
+  validateCustomThemeFile,
+} from "@/lib/theme/custom-theme-image";
+import {
+  deleteCustomThemeImage,
+  hydrateCustomThemeRecords,
+  saveCustomThemeImage,
+} from "@/lib/theme/custom-theme-indexed-db";
+import {
+  getBasePresetThemeId,
+  getResolvedThemeById,
+  getThemeById,
+} from "@/lib/theme/themes";
+import type {
+  CustomThemeCrop,
+  CustomThemeRecord,
+  PendingCustomThemeUpload,
+} from "@/lib/theme/types";
+
+const THEME_STORAGE_KEY = "redbook-content-theme";
+const CUSTOM_THEME_ASSET_ERROR = "自定义主题图片保存失败，请稍后重试";
+const CUSTOM_THEME_ERROR_STORAGE = "主题配置保存失败，请清理浏览器存储后重试";
+const CUSTOM_THEME_LIMIT_ERROR = "最多只能保存 20 个自定义主题";
+
+function getImageStorageKey(themeId: string) {
+  return `custom-theme-image:${themeId}`;
+}
+
+function generateCustomThemeId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `custom-theme-${Date.now()}`;
+}
+
+function canPersistThemeState(value: {
+  currentThemeId: string;
+  adjustments: StyleAdjustments;
+  customThemes: CustomThemeRecord[];
+}) {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  const nextValue = JSON.stringify({
+    state: {
+      ...value,
+      customThemes: value.customThemes.map((theme) => ({
+        ...theme,
+        backgroundImageDataUrl: undefined,
+      })),
+    },
+    version: 0,
+  });
+  const previousValue = window.localStorage.getItem(THEME_STORAGE_KEY);
+
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, nextValue);
+
+    if (previousValue === null) {
+      window.localStorage.removeItem(THEME_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(THEME_STORAGE_KEY, previousValue);
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // ============================================================
 // Content Theme (Image/Markdown styling)
 // ============================================================
 
 interface ContentThemeState {
-  // Current preset theme ID
-  currentThemeId: string;
-
   // User's style adjustments
   adjustments: StyleAdjustments;
+  cancelCustomThemeUpload: () => void;
+  clearThemeError: () => void;
+  commitCustomThemeCrop: (
+    basePresetThemeId: string,
+    name?: string
+  ) => Promise<void>;
+
+  // Current theme ID
+  currentThemeId: string;
+  customThemes: CustomThemeRecord[];
+  deleteCustomTheme: (themeId: string) => void;
+  hasHydratedCustomThemes: boolean;
+  hydrateCustomThemes: () => Promise<void>;
+  isCropperOpen: boolean;
+  pendingUpload: PendingCustomThemeUpload | null;
+  resetAdjustments: () => void;
 
   // Actions
-  selectPresetTheme: (themeId: string) => void;
+  selectTheme: (themeId: string) => void;
+  setAdjustments: (adjustments: Partial<StyleAdjustments>) => void;
   setDensity: (density: Density) => void;
   setFont: (fontId: string) => void;
   setHeadingAlignment: (alignment: HeadingAlignment) => void;
-  setAdjustments: (adjustments: Partial<StyleAdjustments>) => void;
-  resetAdjustments: () => void;
+  startCustomThemeUpload: (file: File) => Promise<void>;
+  themeError: string | null;
+  updatePendingCrop: (crop: Partial<CustomThemeCrop>) => void;
 }
 
 export const useContentThemeStore = create<ContentThemeState>()(
   devtools(
     persist(
-      (set) => ({
+      (set, get) => ({
         currentThemeId: defaultTheme.id,
+        customThemes: [],
+        hasHydratedCustomThemes: false,
+        pendingUpload: null,
+        isCropperOpen: false,
+        themeError: null,
         adjustments: { ...defaultAdjustments },
 
-        selectPresetTheme: (themeId: string) => {
-          const theme = getThemeById(themeId);
+        selectTheme: (themeId: string) => {
+          const { customThemes } = get();
+          const theme = getResolvedThemeById(themeId, customThemes);
           if (theme) {
-            set({ currentThemeId: theme.id });
+            set({ currentThemeId: theme.id, themeError: null });
           }
         },
+
+        startCustomThemeUpload: async (file: File) => {
+          const { currentThemeId, customThemes } = get();
+
+          if (customThemes.length >= CUSTOM_THEME_MAX_COUNT) {
+            set({ themeError: CUSTOM_THEME_LIMIT_ERROR });
+            return;
+          }
+
+          try {
+            validateCustomThemeFile(file);
+            const imageDataUrl = await readFileAsDataUrl(file);
+            const image = await new Promise<HTMLImageElement>(
+              (resolve, reject) => {
+                const instance = new Image();
+                instance.onload = () => resolve(instance);
+                instance.onerror = () =>
+                  reject(new Error("图片加载失败，请更换文件"));
+                instance.src = imageDataUrl;
+              }
+            );
+            const basePresetThemeId = getBasePresetThemeId(
+              currentThemeId,
+              customThemes
+            );
+
+            set({
+              pendingUpload: {
+                imageDataUrl,
+                themeName: getThemeNameFromFile(file.name),
+                basePresetThemeId,
+                crop: getDefaultCustomThemeCrop(
+                  image.naturalWidth,
+                  image.naturalHeight
+                ),
+              },
+              isCropperOpen: true,
+              themeError: null,
+            });
+          } catch (error) {
+            set({
+              pendingUpload: null,
+              isCropperOpen: false,
+              themeError:
+                error instanceof Error ? error.message : "图片处理失败，请重试",
+            });
+          }
+        },
+
+        updatePendingCrop: (crop: Partial<CustomThemeCrop>) =>
+          set((state) => {
+            if (!state.pendingUpload) {
+              return state;
+            }
+
+            return {
+              pendingUpload: {
+                ...state.pendingUpload,
+                crop: clampCustomThemeCrop({
+                  ...state.pendingUpload.crop,
+                  ...crop,
+                }),
+              },
+            };
+          }),
+
+        hydrateCustomThemes: async () => {
+          const { currentThemeId, customThemes, hasHydratedCustomThemes } =
+            get();
+
+          if (hasHydratedCustomThemes) {
+            return;
+          }
+
+          try {
+            const hydratedThemes =
+              await hydrateCustomThemeRecords(customThemes);
+            const fallbackThemeId =
+              getResolvedThemeById(currentThemeId, hydratedThemes)?.id ??
+              getThemeById(getBasePresetThemeId(currentThemeId, hydratedThemes))
+                ?.id ??
+              defaultTheme.id;
+
+            set({
+              currentThemeId: fallbackThemeId,
+              customThemes: hydratedThemes,
+              hasHydratedCustomThemes: true,
+            });
+          } catch {
+            set({
+              hasHydratedCustomThemes: true,
+              themeError: CUSTOM_THEME_ASSET_ERROR,
+            });
+          }
+        },
+
+        commitCustomThemeCrop: async (basePresetThemeId: string, name) => {
+          const { adjustments, customThemes, pendingUpload } = get();
+
+          if (!pendingUpload) {
+            return;
+          }
+
+          try {
+            const croppedImage = await renderCroppedThemeImage(
+              pendingUpload.imageDataUrl,
+              pendingUpload.crop
+            );
+            const resolvedBaseThemeId =
+              getThemeById(basePresetThemeId)?.id ??
+              pendingUpload.basePresetThemeId ??
+              defaultTheme.id;
+            const themeId = generateCustomThemeId();
+            const imageStorageKey = getImageStorageKey(themeId);
+
+            await saveCustomThemeImage(imageStorageKey, croppedImage);
+
+            const nextTheme: CustomThemeRecord = {
+              id: themeId,
+              name: name?.trim() || pendingUpload.themeName,
+              basePresetThemeId: resolvedBaseThemeId,
+              backgroundImageDataUrl: croppedImage,
+              crop: pendingUpload.crop,
+              createdAt: Date.now(),
+              imageStorageKey,
+            };
+            const nextCustomThemes = [nextTheme, ...customThemes];
+
+            if (
+              !canPersistThemeState({
+                currentThemeId: nextTheme.id,
+                adjustments,
+                customThemes: nextCustomThemes,
+              })
+            ) {
+              set({ themeError: CUSTOM_THEME_ERROR_STORAGE });
+              return;
+            }
+
+            set({
+              customThemes: nextCustomThemes,
+              currentThemeId: nextTheme.id,
+              pendingUpload: null,
+              isCropperOpen: false,
+              themeError: null,
+            });
+          } catch (error) {
+            set({
+              themeError:
+                error instanceof Error
+                  ? error.message
+                  : CUSTOM_THEME_ASSET_ERROR,
+            });
+          }
+        },
+
+        cancelCustomThemeUpload: () =>
+          set({
+            pendingUpload: null,
+            isCropperOpen: false,
+          }),
+
+        deleteCustomTheme: (themeId: string) =>
+          set((state) => {
+            const theme = state.customThemes.find(
+              (item) => item.id === themeId
+            );
+            if (!theme) {
+              return state;
+            }
+
+            const nextCustomThemes = state.customThemes.filter(
+              (item) => item.id !== themeId
+            );
+            const nextThemeId =
+              state.currentThemeId === themeId
+                ? (getThemeById(theme.basePresetThemeId)?.id ?? defaultTheme.id)
+                : state.currentThemeId;
+
+            deleteCustomThemeImage(theme.imageStorageKey).catch(
+              () => undefined
+            );
+
+            return {
+              customThemes: nextCustomThemes,
+              currentThemeId: nextThemeId,
+              themeError: null,
+            };
+          }),
+
+        clearThemeError: () => set({ themeError: null }),
 
         setDensity: (density: Density) =>
           set((state) => ({
@@ -68,9 +356,15 @@ export const useContentThemeStore = create<ContentThemeState>()(
         },
       }),
       {
-        name: "redbook-content-theme",
+        name: THEME_STORAGE_KEY,
         partialize: (state) => ({
           currentThemeId: state.currentThemeId,
+          customThemes: state.customThemes.map((theme) => ({
+            ...theme,
+            backgroundImageDataUrl: undefined,
+            imageStorageKey:
+              theme.imageStorageKey || getImageStorageKey(theme.id),
+          })),
           adjustments: state.adjustments,
         }),
       }
@@ -84,8 +378,8 @@ export const useContentThemeStore = create<ContentThemeState>()(
 
 interface SettingsPanelState {
   isOpen: boolean;
-  toggle: () => void;
   setIsOpen: (isOpen: boolean) => void;
+  toggle: () => void;
 }
 
 export const useSettingsPanelStore = create<SettingsPanelState>()((set) => ({


### PR DESCRIPTION
## Summary

支持自定义主题上传与裁剪。

用户现在可以上传背景图，按 3:4 比例裁剪后保存为自定义主题，
并直接用于预览和导出。

## Changes

- 新增自定义主题上传、裁剪、保存流程
- 自定义主题图片改为存储在 IndexedDB，上限为 20

## Snapshots

<img width="1390" height="1378" alt="image" src="https://github.com/user-attachments/assets/f48bab30-76ee-44fd-b7a3-d3225025fe45" />
