### PR TITLE
docs(html2canvas): 补录渐变 transparent 淡出色标踩坑，并收窄 tokens 注释措辞

### DIFF
--- a/docs/html2canvas-pitfalls.md
+++ b/docs/html2canvas-pitfalls.md
@@ -69,3 +69,33 @@ await new Promise<void>((resolve) => {
 ```
 
 **注意**：这个方案在绝大多数场景下可用，但理论上不保证 React 的 commit 已经完成。如果未来遇到截图内容不对的情况，可以考虑使用 `react-dom` 的 `flushSync` 强制同步渲染。
+
+## 6. 渐变里用 `transparent` 淡出，导出后背景发灰发脏
+
+**现象**：带 mesh 渐变的模板（蜜光暖阳、晨雾微光、樱花奶霜、墨夜极光、清新白）浏览器里是正常的暖色/冷色光晕，导出 PNG 后整片背景变成灰褐色。
+
+**原因**：`transparent` 等价于 `rgba(0, 0, 0, 0)`，是"**透明的黑**"。CSS 渐变按**预乘 alpha** 插值，黑色分量不参与，所以浏览器渲染正常；但导出走 html2canvas-pro → Canvas2D 渐变，Canvas2D 按**非预乘** sRGB 插值，RGB 会一路被拉向黑色，中间色因此发灰。
+
+这不是 html2canvas-pro 的 bug —— 它忠实地把 `rgba(0,0,0,0)` 传给了 `addColorStop`。裸 Chrome canvas 做同样的事得到的像素与导出结果逐字节一致，换库或升级都绕不开。
+
+**解决方案**：渐变里**跨区间淡出**的色标必须写成相邻颜色的 alpha 0 版本，不要用 `transparent`。
+
+```ts
+// ✗ 导出后发灰
+"radial-gradient(ellipse at 88% 12%, #ffe7c2 0%, transparent 55%)"
+// ✓ 两种插值空间下一致
+"radial-gradient(ellipse at 88% 12%, #ffe7c2 0%, rgba(255, 231, 194, 0) 55%)"
+```
+
+**例外**：**硬色标**里的 `transparent` 是安全的 —— 两侧位置相同时不存在跨 alpha 的插值区间。`generator.ts` 的 highlight 标题装饰就是这种写法，实测导出 Δ=0，不需要改：
+
+```ts
+// 安全：55%→55%、92%→92% 位置重合，没有渐变区间
+`linear-gradient(180deg, transparent 55%, ${color} 55%, ${color} 92%, transparent 92%)`
+```
+
+但这依赖两侧百分比**严格相等**；一旦把任何一侧改成淡入淡出，就会重新触发上面的问题。
+
+**验证方式**：Playwright 截元素图作 ground truth，与 html2canvas-pro 导出结果逐像素比对通道差。修复前 warmSun 最大通道差 93，修复后 5。
+
+**文件位置**：`src/lib/theme/tokens.ts`（`gradients`）、`src/lib/theme/generator.ts:113`（硬色标例外）

--- a/src/lib/theme/tokens.ts
+++ b/src/lib/theme/tokens.ts
@@ -76,10 +76,14 @@ export const colors = {
 // ============================================================
 
 /**
- * 渐变的淡出色标必须写成"同色 alpha 0"（如 rgba(255, 231, 194, 0)），禁止用
- * `transparent`。`transparent` 等价于 rgba(0, 0, 0, 0)，CSS 按预乘 alpha 插值所以
- * 浏览器里看不出问题，但导出走的 canvas 渐变按非预乘插值，RGB 会一路拉向黑色，
- * 导出图背景发灰发脏。
+ * 渐变里**跨区间淡出**的色标必须写成"同色 alpha 0"（如 rgba(255, 231, 194, 0)），
+ * 不要用 `transparent`。`transparent` 等价于 rgba(0, 0, 0, 0)，CSS 按预乘 alpha
+ * 插值所以浏览器里看不出问题，但导出走的 canvas 渐变按非预乘插值，RGB 会一路拉向
+ * 黑色，导出图背景发灰发脏。
+ *
+ * 例外：硬色标（两侧位置相同，如 `transparent 55%, color 55%`）没有插值区间，用
+ * `transparent` 是安全的 —— generator.ts 的 highlight 标题装饰即为此种。
+ * 详见 docs/html2canvas-pitfalls.md 第 6 条。
  */
 export const gradients = {
   // Light gradients


### PR DESCRIPTION
Refs #9, follows up #10

#10 的 code review 在合并后才回报，两条 finding 都成立，拆为独立 PR 跟进（已合并的历史不再改动）。

## 1. 补 `docs/html2canvas-pitfalls.md` 第 6 条

该文件是本仓库导出类踩坑的既定归档处，已有 5 条，格式统一为 现象 / 原因 / 解决方案 / 文件位置。#9 的根因（`transparent` 即"透明的黑"，CSS 预乘 alpha 插值 vs Canvas2D 非预乘插值）属于完全同一类知识，却只落在了 `tokens.ts` 的一条注释里 —— 这个归档处对它本该覆盖的 bug 类别是不完整的。

## 2. 收窄 `tokens.ts` 注释的措辞

原注释写的是「禁止用 `transparent`」，但 `generator.ts:113` 的 highlight 标题装饰仍在用：

```ts
`linear-gradient(180deg, transparent 55%, ${color} 55%, ${color} 92%, transparent 92%)`
```

那里是**硬色标**（两侧百分比重合 55%→55%、92%→92%），不存在跨 alpha 的插值区间，实测导出 Δ=0，本就安全。但绝对措辞加上一个活的反例摆在另一个文件里，后来者要么会去做无谓的「修复」，要么把整条规则读成建议。

改为限定「**跨区间**淡出」，并显式写出硬色标例外 + 指向文档第 6 条。文档里另注明该例外依赖两侧百分比**严格相等** —— 一旦softening 成淡入淡出就会重新触发原 bug。

## 验证

纯文档与注释改动，无行为变更。渐变逐像素回归比对（Playwright 截图作 ground truth vs html2canvas-pro 导出）复跑仍全 PASS，`ultracite check` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)